### PR TITLE
Improve Makefile and Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# Ignore binary objects and build results
 *.o
+/bin
+/src/c/gen

--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,61 @@
-# TARGET=arm-none-eabi
+# LuPI2 Makefile
 
-#CC=$(TARGET)-gcc
-CC=gcc
+# Default compiler settings.
+CC?=cc
+CFLAGS?=-O2 -std=c99
+LDFLAGS+= -static
 
-CFLAGS=-O2 -g -std=c99 -Isrc/lib/lua -Iinclude
-
+# Project specific stuff
 BUILD = bin/
-SOURCE = src/c/
+SOURCE = src/c
 
 CORELUA = src/lua/core
 RESOURCES = resources
 LIBS=-lm
 
+INCLUDES=-I$(SOURCE) -Isrc/c/lib/lua -Iinclude
+
 GENERATED=include/luares.h src/c/gen/luares.c include/res.h src/c/gen/res.c
 LUAPARAMS = $(CORELUA) include/luares.h src/c/gen/luares.c lua_
 RESPARAMS = $(RESOURCES) include/res.h src/c/gen/res.c res_
-LDFLAGS=-static
 
 SRCDIRECTORIES = $(shell find $(SOURCE) -type d)
-BUILDDIRECTORIES = $(patsubst $(SOURCE)%, $(BUILD)%, $(SRCDIRECTORIES))
+BUILDDIRECTORIES = $(patsubst $(SOURCE)/%, $(BUILD)%, $(SRCDIRECTORIES))
 
 CFILES = $(shell find $(SOURCE) -type f -name '*.c')
-OBJECTS :=	$(patsubst $(SOURCE)%.c, $(BUILD)%.c.o, $(CFILES))
+OBJECTS :=	$(patsubst $(SOURCE)/%.c, $(BUILD)%.c.o, $(CFILES))
 
-#Rules
-#Prepare
+# Targets
+
+# Pseudo Targets
+debug: CFLAGS+= -g
+
 $(BUILDDIRECTORIES):
 	mkdir -p $@
 
-#Build
-all: smallclean $(BUILDDIRECTORIES) resources $(BUILD)lupi
+build: smallclean $(BUILDDIRECTORIES) resources $(BUILD)lupi
 
-build: clean all
+all: clean build
 
 $(BUILD)lupi: $(OBJECTS)
 	$(CC) $(LDFLAGS) $(OBJECTS) -o $@ $(LIBS)
 
-$(BUILD)%.c.o: $(SOURCE)%.c
-	$(CC) -c $(CFLAGS) -I /usr/include -I src/c -I src/c/lib/lua $< -o $@
+$(BUILD)%.c.o: $(SOURCE)/%.c
+	$(CC) -c $(CFLAGS) $(INCLUDES) $< -o $@
 
 #Resources
-resources: cleanresourcues
+resources: cleanresources
 	scripts/txt2c $(LUAPARAMS)
 	scripts/txt2c $(RESPARAMS)
 
-#Clean rules
-cleanresourcues:
+# Clean rules
+cleanresources:
 	-rm -f $(GENERATED)
-	mkdir -p src/c/gen/
-	touch src/c/gen/luares.c
+	mkdir -p $(SOURCE)/gen/
+	touch $(SOURCE)/gen/luares.c
 	touch include/luares.h
 
-clean: cleanresourcues
+clean: cleanresources
 	-rm -rf $(BUILD)
 
 smallclean:


### PR DESCRIPTION
This PR makes the Makefile a bit more structured, functionally, it should behave the same.

The gitignore also ignores /bin and /src/c/gen now, because they are modified during the build.
